### PR TITLE
add subscribe and unsubscribe to message recieve

### DIFF
--- a/siren/index.ts
+++ b/siren/index.ts
@@ -1,3 +1,5 @@
+import * as messagetypes from "./Odyssey-Base/src/types/message.types";
+
 const server = Bun.serve<WebSocketData>({
     port: 3000,
     fetch(req, server) {
@@ -18,13 +20,42 @@ const server = Bun.serve<WebSocketData>({
         },
         message(ws, message) {
 
-            // TODO: allow subscriptions to additional topics and unsubscribing from topics
+            // checks if valid JSON, if not log error and exit
+            let parsedMessage: any;
+            try {
+                parsedMessage = JSON.parse(message.toString());
+            } catch (error) {
+                console.log(error)
+                console.log("This is the malformed message:", message.toString())
+                return;
+            }
 
-            server.publish("test", message);
-            // TODO: allow selection of publishing channel
+            // checks if valid SubscriptionMessage, if not switch to publish block of code
+            // then checks argument fields and subs/unsubs to arguments accordingly
+            const subscriptionMessage = parsedMessage as messagetypes.SubscriptionMessage;
+
+            if (subscriptionMessage.argument && subscriptionMessage.topics) {
+                if (subscriptionMessage.argument == "subscribe") {
+                    for (const topic of subscriptionMessage.topics) {
+                        ws.subscribe(topic);
+                    }
+                } else if (subscriptionMessage.argument == "unsubscribe") {
+                    for (const topic of subscriptionMessage.topics) {
+                        ws.unsubscribe(topic);
+                    }
+                }
+                return;
+            } else {
+
+                // TODO: handle JSON for ServerData checking and publishing in correct topic
+                server.publish("test", message);
+            }
+
+
+
         },
         close(ws) {
-            
+
             if (ws.data.subTopics) {
                 ws.unsubscribe(ws.data.subTopics); // TODO: parse for different topics and unsubscribe to them all
             }

--- a/siren/index.ts
+++ b/siren/index.ts
@@ -31,13 +31,14 @@ const server = Bun.serve<WebSocketData>({
                 return;
             }
 
-            // checks if valid SubscriptionMessage, if not switch to publish block of code
-            // then checks argument fields and subs/unsubs to arguments accordingly
+            
             const subscriptionMessage = parsedMessage as messagetypes.SubscriptionMessage;
 
+            // checks if valid SubscriptionMessage, if not switch to publish block of code
+            // then checks argument fields and subs/unsubs to arguments accordingly
             labelOperationLoop: if (subscriptionMessage.argument && subscriptionMessage.topics) {
 
-                // check the argument field for the correct operation, or break out of if block with an error logged
+                // check the argument field for the correct operation, or break out of the if block with an error logged
                 let isSubscribe: boolean;
                 if (subscriptionMessage.argument == "subscribe") {
                     isSubscribe = true;
@@ -48,7 +49,9 @@ const server = Bun.serve<WebSocketData>({
                     break labelOperationLoop;
                 }
 
+                // iterate through the topics and either subscribe or unsubscribe
                 for (const topic of subscriptionMessage.topics) {
+                    // checks if the topic is present the topic enum in the topic.ts file of Odyssey-Base
                     if ((<any>Object).values(topics.Topic).includes(topic)) {
                         if (isSubscribe) {
                             ws.subscribe(topic);


### PR DESCRIPTION
closes #9 

leaves parsed JSON as `parsedMessage` available for future casting to `ServerData`

3 different behavior paths:
 - logs to console upon JSON parse error, the exits the message
 - silently continues to publish block if valid JSON doesn't contain necessary fields
 - exits the message after a correct JSON is used for sub/unsub