### PR TITLE
add halow v1.5

### DIFF
--- a/odysseus/halow_setup/README.md
+++ b/odysseus/halow_setup/README.md
@@ -1,8 +1,8 @@
 This is the code for Newracom/HaLow setup for Odysseus 22A.  Full details can be found in the NER Confluence.
 
 This setup process is tested for:
-- [NRC sw v1.4.1](https://github.com/newracom/nrc7292_sw_pkg) (+ [NRC RPi setup instructions v1.5](https://github.com/newracom/nrc7292_sw_pkg/blob/master/package/doc/UG-7292-018-Raspberry_Pi_setup.pdf))
-- [NRC SDK v1.5.2](https://github.com/newracom/nrc7292_sdk)
+- [NRC sw v1.5](https://github.com/newracom/nrc7292_sw_pkg) (+ [NRC RPi setup instructions v1.6](https://github.com/newracom/nrc7292_sw_pkg/blob/master/package/doc/UG-7292-018-Raspberry_Pi_setup.pdf))
+- [NRC SDK v1.6](https://github.com/newracom/nrc7292_sdk)
 - OS: Raspberry Pi Lite 64 bit (Bookworm).
 - Hardware: [ALFA AHPI7292S PiHAT](https://docs.alfa.com.tw/Product/AHPI7292S/30_Technical_Details/) (the board data file is different, and in terms of these setup scripts is otherwise interchangable with a NRC EVK)
 

--- a/odysseus/halow_setup/setup_system.sh
+++ b/odysseus/halow_setup/setup_system.sh
@@ -27,7 +27,7 @@ sudo systemctl disable NetworkManager
 sudo systemctl mask NetworkManager
 
 # validate/convert dts to dtbo
-echo "4. Creating spi-dev disable file"
+echo "4. Creating spi-dev disable for SPI 0 file"
 dtc -I dts -O dtb -o "$SCRIPT_DIR"/sources/newracom.dtbo "$SCRIPT_DIR"/sources/newracom.dts
 cp "$SCRIPT_DIR"/sources/newracom.dtbo /boot/overlays/
 

--- a/odysseus/halow_setup/sources/newracom.dts
+++ b/odysseus/halow_setup/sources/newracom.dts
@@ -1,52 +1,50 @@
 /*
-* Device Tree overlay for Newracom
-*
-*/
+ * Device Tree overlay for Newracom
+ *
+ */
 /dts-v1/;
 /plugin/;
 / {
-    compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709", "brcm,bcm2711";
-    fragment@0 {
-        target = <&spi>;
-        __overlay__ {
-            pinctrl-names="default";
-            pinctrl-0=<&nrc_pins>;
-            status = "okay";
+	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709", "brcm,bcm2711";
+	fragment@0 {
+		target = <&spi>;
+		__overlay__ {
+			pinctrl-names="default";
+			pinctrl-0=<&nrc_pins>;
+			status = "okay";
 
-            spidev@0{
-                status = "disabled";
-            };
-            spidev@1{
-                status = "disabled";
-            };
-        };
-    };
-    fragment@1 {
-        target = <&gpio>;
-        __overlay__ {
-            nrc_pins: nrc_pins {
-                brcm,pins = <5 7 8 9 10 11>;
-                brcm,function = <0 1 1 4 4 4>;
-                brcm,pull = <1 2 2 2 2 1>;
-            };
-        };
-    };
+			spidev@0{
+				status = "disabled";
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&gpio>;
+		__overlay__ {
+			nrc_pins: nrc_pins {
+				brcm,pins = <5 7 8 9 10 11>;
+				brcm,function = <0 1 1 4 4 4>;
+				brcm,pull = <1 2 2 2 2 1>;
+			};
+		};
+	};
 
     fragment@2 {
         target = <&spi0>;
-    __overlay__ {
+        __overlay__ {
             pinctrl-names="default";
             pinctrl-0=<&nrc_pins>;
             status = "okay";
             #address-cells = <1>;
             #size-cells = <0>;
 
-            nrc: nrc-cspi@0 { /* Bus Number */
+            nrc: nrc-cspi@0 {               /* Bus Number */
                 compatible ="nrc80211";
-                reg = <0>;   /* CS Number */
+                reg = <0>;                  /* CS Number */
                 interrupt-parent = <&gpio>;
-                interrupts = <5 4>;  /* GPIO Number */ /* IRQ_TYPE_LEVEL_HIGH */
-                spi-max-frequency = <20000000>;   /* Max Freq */
+                interrupts = <5 4>;             /* GPIO Number */ /* IRQ_TYPE_LEVEL_HIGH */
+                spi-max-frequency = <20000000>;     /* Max Freq */
             };
         };
     };


### PR DESCRIPTION
To be merged after #33 .

Halow software v1.5, new device tree overlay which allows for spidev usage on Master SPI 1+. As for nrc driver changes there is ability to set rate control and have rate control follow the sta/ap.  This allows us to "lock" the MCS to a specific level or lock it to match the STA MCS of sent packets.  This does not change the beacon mcs.