### PR TITLE
Buildroot nrc dependency fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,3 @@
 */__pycache__
 
 .DS_Store
-
-odysseus/buildroot

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 */__pycache__
 
 .DS_Store
+
+odysseus/buildroot

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,6 +2,7 @@
 	path = odysseus/buildroot
 	url = https://gitlab.com/buildroot.org/buildroot.git
 	branch = 96d0d677790e659b822761b50561b0316b4abf43
+	ignore = dirty
 [submodule "odysseus/odysseus_tree/sources/nrc7292_sw_pkg"]
 	path = odysseus/odysseus_tree/sources/nrc7292_sw_pkg
 	url = https://github.com/newracom/nrc7292_sw_pkg

--- a/odysseus/README.md
+++ b/odysseus/README.md
@@ -13,10 +13,10 @@ TBD, for now build locally on Linux
 2. Install all buildroot dependencies, including:
     - [All mandatory packages](https://buildroot.org/downloads/manual/manual.html#requirement) (most preinstalled on a normal linux system)
     - python3
+    - libxcrypt (for linux kernel)
     - ncurses5 (or 6) (for menuconfig)
     - Git, rsync
     - graphviz, python-matplotlib, and dotx for graph creation (optional)
-    
 
 <!-- ## Start Container on MacOS/Linux
 In any terminal that is in the directory:

--- a/odysseus/odysseus_tree/package/nrc7292/nrc7292.mk
+++ b/odysseus/odysseus_tree/package/nrc7292/nrc7292.mk
@@ -9,11 +9,6 @@ NRC7292_DEPENDENCIES += host-dtc
 # set the makefile KDIR to buildroot kernel, as otherwise it will use host headers
 NRC7292_MODULE_MAKE_OPTS = KDIR=$(LINUX_DIR)
 
-# for some reason host-objtool is being blocked as dependency conflict, so this is a hacky way to make it available again
-define NRC7292_MODULE_LINUX_OBJTOOL_FIX
-   $(MAKE) -C $(LINUX_DIR)/tools/objtool
-endef
-
 # set custom bd file to default (evk) if unset, also set firmware file (unchainging)
 BR2_PACKAGE_NRC7292_CUSTOM_BD_FILE ?=  $(BR2_EXTERNAL_ODY_TREE_PATH)/sources/nrc7292_sw_pkg/package/evk/binary/nrc7292_bd.dat
 NRC7292_FIRMWARE_FILE = $(BR2_EXTERNAL_ODY_TREE_PATH)/sources/nrc7292_sw_pkg/package/evk/binary/nrc7292_cspi.bin
@@ -22,8 +17,6 @@ define NRC7292_INSTALL_TARGET_CMDS
 	$(INSTALL) -D -m 0644 $(BR2_PACKAGE_NRC7292_CUSTOM_BD_FILE) $(TARGET_DIR)/lib/firmware/nrc7292_bd.dat
 	$(INSTALL) -D -m 0644 $(NRC7292_FIRMWARE_FILE) $(TARGET_DIR)/lib/firmware/nrc7292_cspi.bin
 endef
-
-NRC7292_PRE_BUILD_HOOKS += NRC7292_MODULE_LINUX_OBJTOOL_FIX
 
 NRC7292_POST_BUILD_HOOKS += NRC7292_BUILD_DTO
 

--- a/odysseus/odysseus_tree/package/nrc7394/nrc7394.mk
+++ b/odysseus/odysseus_tree/package/nrc7394/nrc7394.mk
@@ -9,11 +9,6 @@ NRC7394_DEPENDENCIES += host-dtc
 # set the makefile KDIR to buildroot kernel, as otherwise it will use host headers
 NRC7394_MODULE_MAKE_OPTS = KDIR=$(LINUX_DIR)
 
-# for some reason host-objtool is being blocked as dependency conflict, so this is a hacky way to make it available again
-define NRC7394_MODULE_LINUX_OBJTOOL_FIX
-   $(MAKE) -C $(LINUX_DIR)/tools/objtool
-endef
-
 # set custom bd file to default (evk) if unset, also set firmware file (unchainging)
 BR2_PACKAGE_NRC7394_CUSTOM_BD_FILE ?=  $(BR2_EXTERNAL_ODY_TREE_PATH)/sources/nrc7394_sw_pkg/package/evk/binary/nrc7394_bd.dat
 NRC7394_FIRMWARE_FILE = $(BR2_EXTERNAL_ODY_TREE_PATH)/sources/nrc7394_sw_pkg/package/evk/binary/nrc7394_cspi.bin
@@ -22,8 +17,6 @@ define NRC7394_INSTALL_TARGET_CMDS
 	$(INSTALL) -D -m 0644 $(BR2_PACKAGE_NRC7394_CUSTOM_BD_FILE) $(TARGET_DIR)/lib/firmware/nrc7394_bd.dat
 	$(INSTALL) -D -m 0644 $(NRC7394_FIRMWARE_FILE) $(TARGET_DIR)/lib/firmware/nrc7394_cspi.bin
 endef
-
-NRC7394_PRE_BUILD_HOOKS += NRC7394_MODULE_LINUX_OBJTOOL_FIX
 
 NRC7394_POST_BUILD_HOOKS += NRC7394_BUILD_DTO
 


### PR DESCRIPTION
This fixes an issue where basically I was manually using the libelf dependency to build a tool that nrc apparently does not need.  I realized it when building in a near-chroot on a new linux distro I am trying out.

It now builds without libelf cleanly.  Most likely objtool was not being pulled in before due to issues with the kernel defconfig and kmod that was resolved with #33.

Also fixes where git complains of the dirty submodule, as we know it gets dirty because of the dhcpcd fix.