### PR TITLE
Adding in PR and ticket templates to this repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-form.yml
+++ b/.github/ISSUE_TEMPLATE/bug-form.yml
@@ -1,0 +1,34 @@
+name: Bug
+description: For any issue related to a bug
+title: '[Area] - Short Description'
+labels: [bug]
+body:
+  - type: textarea
+    id: observed-behavior
+    attributes:
+      label: Observed Behavior
+      description: What happened?
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: What should have happened?
+    validations:
+      required: true
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: How could someone reproduce this bug?
+      value: "1. \n2. \n3. "
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots (as needed)
+      description: Add screenshots of the bug if applicable
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,0 +1,64 @@
+name: Epic
+description: A collection of many tasks
+title: '[Area] - Short Description'
+labels: [epic]
+body:
+  - type: textarea
+    id: overview
+    attributes:
+      label: Overview
+      description: Provide a brief summary of this epic
+    validations:
+      required: true
+  - type: textarea
+    id: stakeholders
+    attributes:
+      label: Stakeholders
+      description: Who to contact for this epic?
+      value: |
+        Product Stakeholder:
+        Software Stakeholder:
+        Reference Users:
+  - type: textarea
+    id: metrics
+    attributes:
+      label: Success Metrics
+      description: What are the metrics we will use to determine if this is successful?
+    validations:
+      required: true
+  - type: textarea
+    id: rollout
+    attributes:
+      label: Rollout Plan
+      description: How will this be released? All at once? In parts?
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Out of Scope
+      description: What is not included in this epic?
+    validations:
+      required: true
+  - type: textarea
+    id: background-context
+    attributes:
+      label: Background / Context
+      description: What is the context for this epic? What already exists?
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: How are we evaluating the success of this epic?
+    validations:
+      required: true
+  - type: textarea
+    id: tickets
+    attributes:
+      label: Tickets
+      description: What tickets will be a part of this epic?
+      value: " - [ ] #\n - [ ] #"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,26 @@
+name: Feature Request
+description: Suggest a new feature for the project
+title: '[Area] - Short Description'
+labels: [new feature]
+body:
+  - type: textarea
+    id: current-features
+    attributes:
+      label: Current Features
+      description: What exists currently?
+    validations:
+      required: true
+  - type: textarea
+    id: desired-features
+    attributes:
+      label: Desired Additional Features
+      description: What features do you want to add?
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots (as needed)
+      description: Add screenshots of the current or desired state if applicable
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/other.yml
+++ b/.github/ISSUE_TEMPLATE/other.yml
@@ -1,0 +1,18 @@
+name: Other
+description: For issues that don't fit the other categories
+title: '[Area] - Short Description'
+body:
+  - type: textarea
+    id: desired-changes
+    attributes:
+      label: Desired Changes
+      description: What changes do you want to make?
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots (as needed)
+      description: Add screenshots if applicable
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/spike.yml
+++ b/.github/ISSUE_TEMPLATE/spike.yml
@@ -1,0 +1,38 @@
+name: Spike
+description: For any research or investigation into a feature or our current architecture
+title: '[Area] - Short Description'
+labels: [spike]
+body:
+  - type: markdown
+    attributes:
+      value: For a spike ticket, please make sure to remember to add links to the resources you are pulling information from so others who are reviewing and giving feedback can also take a look at the same information you are looking at.
+  - type: dropdown
+    id: spike-type
+    attributes:
+      label: Spike Type
+      description: Is this spike about the product (functional) or the implementation of the product (technical)?
+      multiple: true
+      options:
+        - Functional
+        - Technical
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What is this spike ticket looking into/trying to solve? Is this about enhancing something we currently do or looking into a new feature?
+    validations:
+      required: true
+  - type: textarea
+    id: purpose
+    attributes:
+      label: Reason for Spike
+      description: Why is this spike ticket necessary?
+    validations:
+      required: true
+  - type: textarea
+    id: sidenotes
+    attributes:
+      label: Additional notes
+      description: Add any extra comments related to the spike.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,25 @@
+name: Task
+description: Create a task that a developer can complete.
+title: '[Area] - Short Description'
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Provide a brief summary of this issue
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: What are the conditions that need to be satisified to complete this task?
+    validations:
+      required: true
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed Solution
+      description: How will this solution be implemented? What will be changed or added?
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,36 @@
+## Changes
+
+_Explanation of changes goes here_
+
+## Notes
+
+_Any other notes go here_
+
+## Test Cases
+
+- Case A
+- Edge case
+- ...
+
+## To Do
+
+_Any remaining things that need to get done_
+
+- [ ] item 1
+- [ ] ...
+
+## Checklist
+
+It can be helpful to check the `Checks` and `Files changed` tabs.
+Please reach out to your Project Lead if anything is unclear.
+Please request reviewers and ping on slack only after you've gone through this whole checklist.
+
+- [ ] All commits are tagged with the ticket number
+- [ ] No merge conflicts
+- [ ] All checks passing
+- [ ] Remove any non-applicable sections of this template
+- [ ] Assign the PR to yourself
+- [ ] Request reviewers & ping on Slack
+- [ ] PR is linked to the ticket (fill in the closes line below)
+
+Closes # (issue #)


### PR DESCRIPTION
Adding in PR templates and ticket templates like I did for all the other firmware related repos. These are in line with what Finishline is using such that developers can have a fairly standardized experience across all software at NER